### PR TITLE
fix: remove cac version override

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -23,7 +23,6 @@ export function parseArgs(): ParsedArgs {
     const cli = cac('bumpp')
 
     cli
-      .version(version)
       .usage('[...files]')
       .option('--preid <preid>', 'ID for prerelease')
       .option('--all', 'Include all files')


### PR DESCRIPTION
With `.version`, cac doesn't let me use the `--version` argument:

```
➜  nr release --version 0.0.1-dev.2

> @0.0.1-dev.1 release /Users/enzoinnocenzi/Code/projects/hybridly/hybridly
> bumpp package.json packages/*/package.json --commit --push --tag "--version" "0.0.1-dev.2"

bumpp/8.2.1 darwin-arm64 node-v18.10.0
8.2.1
```

I'm trying to run `bumpp` through another CLI so I can't have it interactive. I want to run `nr bumpp --version <version>` without any interaction, but currently I can't.