### PR TITLE
chore: fix typo in cli options

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -37,7 +37,7 @@ export async function parseArgs(): Promise<ParsedArgs> {
       .option('--no-verify', 'Skip git verification')
       .option('--ignore-scripts', `Ignore scripts (default: ${bumpConfigDefaults.ignoreScripts})`)
       .option('-q, --quiet', 'Quiet mode')
-      .option('-v, --version <version>', 'Tagert version')
+      .option('-v, --version <version>', 'Target version')
       .option('-x, --execute <command>', 'Commands to execute after version bumps')
       .help()
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Small typo in options:

```
Options:
  -v, --version <version>  Tagert version 
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
