### PR TITLE
fix: allow to use %s placeholder in execute command

### DIFF
--- a/src/version-bump.ts
+++ b/src/version-bump.ts
@@ -71,7 +71,7 @@ export async function versionBump(arg: VersionBumpOptions | string = {}): Promis
 
   if (operation.options.execute) {
     console.log(symbols.info, 'Executing script', operation.options.execute)
-    await ezSpawn.async(operation.options.execute, { stdio: 'inherit' })
+    await ezSpawn.async(formatVersionString(operation.options.execute, operation.state.newVersion), { stdio: 'inherit' })
     console.log(symbols.success, 'Script finished')
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hey! It will be nice to use `%s` placeholder in `--execute`

### Linked Issues

#10

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
