### PR TITLE
fix: tsup build esm import `ReleaseType` error

### DIFF
--- a/src/release-type.ts
+++ b/src/release-type.ts
@@ -1,6 +1,6 @@
-import { ReleaseType } from 'semver'
+import type { ReleaseType } from 'semver'
 
-export { ReleaseType }
+export type { ReleaseType }
 
 /**
  * The different types of pre-releases.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  banner: ({ format }) => {
+    if (format === "esm") {
+      return {
+        js: "import {createRequire as __createRequire} from 'module';var require=__createRequire(import.meta.url);",
+      };
+    }
+  },
+});


### PR DESCRIPTION
### Description

This PR contains two fixes.

One is the extra ts type `ReleaseType` in the build,
and the other is that when `tsup` is packing, it encounters `picocolors` to generate esm and builds an invalid `__require`.
`Dynamic require of "tty" is not supported`

### Linked Issues

fixes #9 

### Additional context

referenced from [为什么是 tsup](https://modyqyw.top/blogs/2022/12/why-tsup.html#dynamic-require) and discussion [Make require work in ESM bundle](https://github.com/egoist/tsup/discussions/505)