### PR TITLE
fix: allow creating empty commits

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -11,7 +11,7 @@ export async function gitCommit(operation: Operation): Promise<Operation> {
 
   const { all, noVerify, message } = operation.options.commit
   const { updatedFiles, newVersion } = operation.state
-  let args = []
+  let args = ['--allow-empty']
 
   if (all) {
     // Commit ALL files, not just the ones that were bumped


### PR DESCRIPTION
### Description

After selecting `as-is`

```shell
> npx -y bumpp

? Current version 0.0.1 ›
            major 1.0.0
            minor 0.1.0
            patch 0.0.2
             next 0.0.2
        pre-patch 0.0.2-beta.0
        pre-minor 0.1.0-beta.0
        pre-major 1.0.0-beta.0
❯           as-is 0.0.1
           custom ...
```

It throws the following

```shell
> npx -y bumpp

✔ Current version 0.0.1 ›         as-is 0.0.1

   files package.json
  commit chore: release v0.0.1
     tag v0.0.1
    push yes

    from 0.0.1
      to 0.0.1

✔ Bump? … yes
ℹ package.json did not need to be updated
git commit --message "chore: release v0.0.1" exited with a status of 1.
 ELIFECYCLE  Command failed with exit code 1.
```

Because there is no changes (version in package.json hasn't changed). I guess `bumpp` should allow creating empty commits (the `as-is` option means just that, right?)

### Linked Issues

-

### Additional context

-
