### PR TITLE
fix: version update in `package-lock.json`

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,6 +9,17 @@ export interface Manifest {
 }
 
 /**
+ * The npm package lock manifest (package-lock.json)
+ */
+export interface PackageLockManifest extends Manifest {
+  packages: {
+    '': {
+      version: string
+    }
+  }
+}
+
+/**
  * Determines whether the specified value is a package manifest.
  */
 export function isManifest(obj: any): obj is Manifest {
@@ -17,6 +28,18 @@ export function isManifest(obj: any): obj is Manifest {
     && isOptionalString(obj.name)
     && isOptionalString(obj.version)
     && isOptionalString(obj.description)
+}
+
+/**
+ * Determines whether the specified manifest is package-lock.json
+ */
+export function isPackageLockManifest(
+  manifest: Manifest
+): manifest is PackageLockManifest {
+  return (
+    typeof (manifest as PackageLockManifest).packages?.['']?.version ===
+    'string'
+  )
 }
 
 /**

--- a/src/update-files.ts
+++ b/src/update-files.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path'
 import { readJsonFile, readTextFile, writeJsonFile, writeTextFile } from './fs'
-import { isManifest } from './manifest'
+import { isManifest, isPackageLockManifest } from './manifest'
 import type { Operation } from './operation'
 import { ProgressEvent } from './types/version-bump-progress'
 
@@ -67,6 +67,9 @@ async function updateManifestFile(relPath: string, operation: Operation): Promis
 
   if (isManifest(file.data) && file.data.version !== newVersion) {
     file.data.version = newVersion
+    if (isPackageLockManifest(file.data)) {
+      file.data.packages[''].version = newVersion
+    }
     await writeJsonFile(file)
     modified = true
   }


### PR DESCRIPTION
### Description

should also update `packages[""].version` in `package-lock.json`.

### Linked Issues


### Additional context

https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json#packages
