### PR TITLE
fix: recursive option not work when directly call versionBump

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,6 +1,7 @@
 import process from 'node:process'
 import { valid as isValidVersion } from 'semver'
 import cac from 'cac'
+import c from 'picocolors'
 import { isReleaseType } from '../release-type'
 import type { VersionBumpOptions } from '../types/version-bump-options'
 import { version } from '../../package.json'
@@ -53,6 +54,9 @@ export async function parseArgs(): Promise<ParsedArgs> {
         parsedArgs.options.files.shift()
       }
     }
+
+    if (parsedArgs.options.recursive && parsedArgs.options.files?.length)
+      console.log(c.yellow('The --recursive option is ignored when files are specified'))
 
     return parsedArgs
   }

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,10 +1,6 @@
 import process from 'node:process'
-import fs from 'node:fs/promises'
-import fsSync from 'node:fs'
 import { valid as isValidVersion } from 'semver'
 import cac from 'cac'
-import c from 'picocolors'
-import yaml from 'js-yaml'
 import { isReleaseType } from '../release-type'
 import type { VersionBumpOptions } from '../types/version-bump-options'
 import { version } from '../../package.json'
@@ -55,35 +51,6 @@ export async function parseArgs(): Promise<ParsedArgs> {
       if (firstArg === 'prompt' || isReleaseType(firstArg) || isValidVersion(firstArg)) {
         parsedArgs.options.release = firstArg
         parsedArgs.options.files.shift()
-      }
-    }
-
-    if (parsedArgs.options.recursive) {
-      if (parsedArgs.options.files?.length) {
-        console.log(c.yellow('The --recursive option is ignored when files are specified'))
-      }
-      else {
-        parsedArgs.options.files = [
-          'package.json',
-          'package-lock.json',
-          'packages/**/package.json',
-          'jsr.json',
-          'jsr.jsonc',
-        ]
-
-        // check if pnpm-workspace.yaml exists, if so, add all workspaces to files
-        if (fsSync.existsSync('pnpm-workspace.yaml')) {
-          // read pnpm-workspace.yaml
-          const pnpmWorkspace = await fs.readFile('pnpm-workspace.yaml', 'utf8')
-          // parse yaml
-          const workspaces = yaml.load(pnpmWorkspace) as { packages: string[] }
-          // append package.json to each workspace string
-          const workspacesWithPackageJson = workspaces.packages.map(workspace => `${workspace}/package.json`)
-          // start with ! or already in files should be excluded
-          const withoutExcludedWorkspaces = workspacesWithPackageJson.filter(workspace => !workspace.startsWith('!') && !parsedArgs.options.files?.includes(workspace))
-          // add to files
-          parsedArgs.options.files = parsedArgs.options.files.concat(withoutExcludedWorkspaces)
-        }
       }
     }
 

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -105,10 +105,6 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
   else if (raw.commit || tag || push)
     commit = { all, noVerify, message: 'chore: release v' }
 
-  raw.files = raw.files?.length
-    ? raw.files
-    : ['package.json', 'package-lock.json', 'jsr.json', 'jsr.jsonc']
-
   if (recursive) {
     if (raw.files?.length) {
       console.log(c.yellow('The --recursive option is ignored when files are specified'))
@@ -136,6 +132,11 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
         raw.files = raw.files.concat(withoutExcludedWorkspaces)
       }
     }
+  }
+  else {
+    raw.files = raw.files?.length
+      ? raw.files
+      : ['package.json', 'package-lock.json', 'jsr.json', 'jsr.jsonc']
   }
 
   const files = await fg(

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -1,5 +1,9 @@
 import process from 'node:process'
+import fs from 'node:fs/promises'
+import fsSync from 'node:fs'
 import fg from 'fast-glob'
+import c from 'picocolors'
+import yaml from 'js-yaml'
 import type { ReleaseType } from './release-type'
 import { isReleaseType } from './release-type'
 import type { VersionBumpOptions } from './types/version-bump-options'
@@ -74,6 +78,7 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
   const cwd = raw.cwd || process.cwd()
   const ignoreScripts = Boolean(raw.ignoreScripts)
   const execute = raw.execute
+  const recursive = Boolean(raw.recursive)
 
   let release: Release
   if (!raw.release || raw.release === 'prompt')
@@ -100,10 +105,41 @@ export async function normalizeOptions(raw: VersionBumpOptions): Promise<Normali
   else if (raw.commit || tag || push)
     commit = { all, noVerify, message: 'chore: release v' }
 
+  raw.files = raw.files?.length
+    ? raw.files
+    : ['package.json', 'package-lock.json', 'jsr.json', 'jsr.jsonc']
+
+  if (recursive) {
+    if (raw.files?.length) {
+      console.log(c.yellow('The --recursive option is ignored when files are specified'))
+    }
+    else {
+      raw.files = [
+        'package.json',
+        'package-lock.json',
+        'packages/**/package.json',
+        'jsr.json',
+        'jsr.jsonc',
+      ]
+
+      // check if pnpm-workspace.yaml exists, if so, add all workspaces to files
+      if (fsSync.existsSync('pnpm-workspace.yaml')) {
+        // read pnpm-workspace.yaml
+        const pnpmWorkspace = await fs.readFile('pnpm-workspace.yaml', 'utf8')
+        // parse yaml
+        const workspaces = yaml.load(pnpmWorkspace) as { packages: string[] }
+        // append package.json to each workspace string
+        const workspacesWithPackageJson = workspaces.packages.map(workspace => `${workspace}/package.json`)
+        // start with ! or already in files should be excluded
+        const withoutExcludedWorkspaces = workspacesWithPackageJson.filter(workspace => !workspace.startsWith('!') && !raw.files?.includes(workspace))
+        // add to files
+        raw.files = raw.files.concat(withoutExcludedWorkspaces)
+      }
+    }
+  }
+
   const files = await fg(
-    raw.files?.length
-      ? raw.files
-      : ['package.json', 'package-lock.json', 'jsr.json', 'jsr.jsonc'],
+    raw.files,
     {
       cwd,
       onlyFiles: true,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I want to integrate `bumpp` with `release-it`, but recursive options only work in cli.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
