### PR TITLE
fix: respect the CLI args format like `--tag=%s`

### DIFF
--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -93,8 +93,10 @@ export function loadCliArgs(argv = process.argv) {
   const rawArgs = cli.rawArgs
   const args = result.options
 
-  const hasCommitFlag = rawArgs.some(arg => ['-c', '--commit', '--no-commit'].includes(arg))
-  const hasTagFlag = rawArgs.some(arg => ['-t', '--tag', '--no-tag'].includes(arg))
+  const COMMIT_REG = /(-c|--commit|--no-commit)(=.*|$)/
+  const TAG_REG = /(-t|--tag|--no-tag)(=.*|$)/
+  const hasCommitFlag = rawArgs.some(arg => COMMIT_REG.test(arg))
+  const hasTagFlag = rawArgs.some(arg =>TAG_REG.test(arg))
 
   const { tag, commit, ...rest } = args
 

--- a/test/parse-args.test.ts
+++ b/test/parse-args.test.ts
@@ -35,4 +35,28 @@ describe('loadCliArgs', async () => {
 
     expect(result.args.commit).toBe(false)
   })
+
+  it('sets the commit property to "release: %s" if `--commit=release: %s` is present', () => {
+    const result = loadCliArgs([...defaultArgs, '--commit=release: %s'])
+
+    expect(result.args.commit).toBe('release: %s')
+  })
+
+  it('sets the commit property to "release: %s" if `-c=release: %s` is present', () => {
+    const result = loadCliArgs([...defaultArgs, '-c=release: %s'])
+
+    expect(result.args.commit).toBe('release: %s')
+  })
+
+  it('sets the commit property to "release: %s" if `-c "release: %s"` is present', () => {
+    const result = loadCliArgs([...defaultArgs, '-c', 'release: %s'])
+
+    expect(result.args.commit).toBe('release: %s')
+  })
+
+  it('should not match args that contains `--commit` or `-c`', () => {
+    const result = loadCliArgs([...defaultArgs, '--commitrc'])
+
+    expect(result.args.commit).toBe(undefined)
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `commit` and `tag` CLI args are not recognized correctly when using format like `--tag=%s`, while `--tag %s` can be recognized. Both of these formats should be valid.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

fix #31 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
